### PR TITLE
Revert header to older version while keeping theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,10 +12,6 @@
 <body>
     <div class="container">
         <header>
-            <div class="header-content">
-                <h1>Course Materials Assistant</h1>
-                <p class="subtitle">Ask questions about courses, instructors, and content</p>
-            </div>
             <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" title="Toggle light/dark theme">
                 <svg class="theme-icon sun-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -71,29 +71,13 @@ body {
 /* Header */
 header {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     padding: 1rem 2rem;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
+    background: var(--background);
     transition: var(--transition);
 }
 
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -822,10 +806,6 @@ details[open] .suggested-header::before {
     
     header {
         padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
     }
     
     .chat-messages {


### PR DESCRIPTION
Fixes #2

Reverted the header to the older version as requested while preserving theme toggle functionality.

## Changes
- Removed "Course Materials Assistant" header title
- Removed "Ask questions about courses, instructors, and content" subtitle
- Removed horizontal border below header
- Kept theme toggle button with full functionality
- Simplified header layout to minimal design

🤖 Generated with [Claude Code](https://claude.ai/code)